### PR TITLE
Cramer 2019 02 07 update blazor

### DIFF
--- a/Build/BlazorTemplate.yml
+++ b/Build/BlazorTemplate.yml
@@ -19,7 +19,7 @@ queue:
 variables:
  Major: '0'
  Minor: '4'
- Patch: '0'
+ Patch: '1'
  Version: "$(Major).$(Minor).$(Patch)"
 
 steps:

--- a/Build/BlazorTemplate.yml
+++ b/Build/BlazorTemplate.yml
@@ -43,15 +43,6 @@ steps:
     command: test
     projects: "**/*Tests/*.csproj"
     configurationToPack: debug
-
-#- task: DotNetCoreCLI@2
-#  displayName: dotnet pack blazor-state
-#  inputs:
-#    command: pack
-#    packagesToPack: 'source\BlazorState\BlazorState.csproj'
-#    versionEnvVar: Version
-#    versioningScheme: byEnvVar
-#    configurationToPack: debug
     
 - task: NuGetCommand@2
   displayName: 'NuGet pack Templates'
@@ -66,12 +57,30 @@ steps:
   displayName: Publish Artifact
   inputs:
     PathtoPublish: '$(build.artifactstagingdirectory)'
-    ArtifactName: drop
+    ArtifactName: TemplateNuget
     publishLocation: Container
 
-- task: NuGetCommand@2
-  displayName: Push Nuget to Nuget
+- task: DotNetCoreCLI@2
+  displayName: Publish The template Server project which will be deployed to azure
   inputs:
-    command: push
-    nuGetFeedType: external
-    publishFeedCredentials: Nuget.org
+    command: publish
+    publishWebProjects: false
+    projects: 'source/TimeWarp.AspNetCore.Blazor.Templates/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Server/BlazorHosted-CSharp.Server.csproj'
+    arguments: '--configuration $(BuildConfiguration) --output $(build.artifactstagingdirectory)'
+  enabled: true
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish Artifact
+  inputs:
+    PathtoPublish: '$(build.artifactstagingdirectory)'
+    ArtifactName: DefaultTemplateSite
+    publishLocation: Container
+
+
+# part of the release pipeline
+# - task: NuGetCommand@2
+#   displayName: Push Nuget to Nuget
+#   inputs:
+#     command: push
+#     nuGetFeedType: external
+#     publishFeedCredentials: Nuget.org

--- a/Build/ConsoleTemplate.yml
+++ b/Build/ConsoleTemplate.yml
@@ -17,7 +17,7 @@ queue:
 variables:
  Major: '0'
  Minor: '0'
- Patch: '2'
+ Patch: '3'
  Version: "$(Major).$(Minor).$(Patch)"
  Configuration: debug
 

--- a/Build/Development/ConsoleTemplate.yml
+++ b/Build/Development/ConsoleTemplate.yml
@@ -17,7 +17,7 @@ queue:
 variables:
  Major: '0'
  Minor: '0'
- Patch: '2'
+ Patch: '3'
  Version: "$(Major).$(Minor).$(Patch)-beta-$(Build.BuildID)"
  Configuration: debug
 

--- a/Build/Development/blazor-state.yml
+++ b/Build/Development/blazor-state.yml
@@ -1,8 +1,8 @@
-name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+﻿name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 variables:
   Major: '0'
   Minor: '4'
-  Patch: '0'
+  Patch: '1'
   Version: "$(Major).$(Minor).$(Patch)-beta-$(Build.BuildID)"
   Configuration: debug
 trigger:

--- a/Build/blazor-state.yml
+++ b/Build/blazor-state.yml
@@ -18,7 +18,7 @@ queue:
 variables:
  Major: '0'
  Minor: '4'
- Patch: '0'
+ Patch: '1'
  Version: "$(Major).$(Minor).$(Patch)"
 steps:
 - script: echo Version $(Version)

--- a/Tools/SetVersions.ps1
+++ b/Tools/SetVersions.ps1
@@ -1,3 +1,3 @@
-tools SetVersion --Project BlazorState --Major 0 --Minor 4 --Patch 0
-tools SetVersion --Project BlazorTemplate --Major 0 --Minor 4 --Patch 0
-tools SetVersion --Project ConsoleTemplate --Major 0 --Minor 0 --Patch 2
+tools SetVersion --Project BlazorState --Major 0 --Minor 4 --Patch 1
+tools SetVersion --Project BlazorTemplate --Major 0 --Minor 4 --Patch 1
+tools SetVersion --Project ConsoleTemplate --Major 0 --Minor 0 --Patch 3

--- a/source/BlazorState/BlazorState.csproj
+++ b/source/BlazorState/BlazorState.csproj
@@ -32,7 +32,7 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeJsDll</TargetsForTfmSpecificBuildOutput>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>./bin/Packages</PackageOutputPath>
-    <PackageVersion>0.4.0</PackageVersion>
+    <PackageVersion>0.4.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <!-- Versioning properties -->
   <PropertyGroup>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
   </PropertyGroup>
 

--- a/source/TimeWarp.AspNetCore.Blazor.Templates/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/BlazorHosted-CSharp.Client.csproj
+++ b/source/TimeWarp.AspNetCore.Blazor.Templates/content/TimeWarp.BlazorHosted-CSharp/Source/BlazorHosted-CSharp.Client/BlazorHosted-CSharp.Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazor-State" Version="0.4.0" />
+    <PackageReference Include="Blazor-State" Version="0.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="0.8.0-preview-19104-04" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.8.0-preview-19104-04" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
Bump Version number and move template NuGet publishing to the release pipeline. Vs the Build.
Generate two artifacts from the build.  1 is Nuget packages other is the site generated from the template.