### PR TITLE
Move version specs to directory.build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,13 +44,16 @@
     <FixieConsoleVersion>2.0.4</FixieConsoleVersion>
     <MediatrExtensionsMicrosoftDependencyInjectionVersion>6.0.1</MediatrExtensionsMicrosoftDependencyInjectionVersion>
     <MediatrVersion>6.0.0</MediatrVersion>
+    <MoqVersion>4.10.1</MoqVersion>
     <ScrutorVersion>3.0.2</ScrutorVersion>
+    <SeleniumSupportVersion>3.141.0</SeleniumSupportVersion>
+    <SeleniumWebDriverVersion>3.141.0</SeleniumWebDriverVersion>
     <ShouldlyVersion>3.0.2</ShouldlyVersion>
     <TypeSupportVersion>1.0.73</TypeSupportVersion>
 
   </PropertyGroup>
     
-  <!--Not sure why I added this.-->
+  <!--This is to add the SHA for the commit to your assembly InformationalVersion -->
   <Choose>
     <When Condition="'$(OfficialBuild)' != 'true'">
       <!-- On non-official builds we don't burn in a git sha. In large part because it

--- a/test/TestApp.Client.Integration.Tests/TestApp.Client.Integration.Tests.csproj
+++ b/test/TestApp.Client.Integration.Tests/TestApp.Client.Integration.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Fixie" Version="$(FixieVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostVersion)" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="Scrutor" Version="$(ScrutorVersion)" />
     <PackageReference Include="Shouldly" Version="$(ShouldlyVersion)" />
     <DotNetCliToolReference Include="Fixie.Console" Version="$(FixieConsoleVersion)" />

--- a/test/TestApp.EndToEnd.Tests/TestApp.EndToEnd.Tests.csproj
+++ b/test/TestApp.EndToEnd.Tests/TestApp.EndToEnd.Tests.csproj
@@ -6,10 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="Fixie" Version="$(FixieVersion)" />
-    <PackageReference Include="Selenium.Support" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
+    <PackageReference Include="Selenium.Support" Version="$(SeleniumSupportVersion)" />
+    <PackageReference Include="Selenium.WebDriver" Version="$(SeleniumSupportVersion)" />
     <PackageReference Include="Shouldly" Version="$(ShouldlyVersion)" />
-    <DotNetCliToolReference Include="Fixie.Console" Version="2.0.1" />
+    <DotNetCliToolReference Include="Fixie.Console" Version="$(FixieConsoleVersion)" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 


### PR DESCRIPTION
The gola is to have all the versions in one place and be consistent across the sln