### PR TITLE
It seems that something tries to recreate the _content stuff each tim…

### DIFF
--- a/Build/blazor-state.yml
+++ b/Build/blazor-state.yml
@@ -39,10 +39,10 @@ steps:
 
 # Delete files
 # Delete folders, or files matching a pattern
-#- task: DeleteFiles@1
-#  inputs: 
-#    sourceFolder: source/BlazorState.Js/bin
-#    contents: \*
+- task: DeleteFiles@1
+  inputs: 
+    sourceFolder: source/BlazorState.Js/bin
+    contents: \*
 
 - task: DotNetCoreCLI@2
   displayName: Run all Tests in the repo gather coverage data


### PR DESCRIPTION
…e and if it is there already refuses to write over it. So I am adding Delete for it.  Which I am guessing will cause the first one to work but the next will give same error.

C:\Users\StevenTCramer\.nuget\packages\microsoft.aspnetcore.blazor.build\3.0.0-preview7.19365.7\targets\Blazor.MonoRuntime.targets(12,5): warning MSB3026: Could not copy "C:\agent\_work\6\s\test\TestApp\TestApp.Client\obj\Debug\netstandard2.0\blazor\_content\BlazorState.Js\blazorstate.js" to "C:\agent\_work\6\s\test\TestApp\TestApp.Client\bin\Debug\netstandard2.0\dist/_content/BlazorState.Js\blazorstate.js". Beginning retry 1 in 1000ms. Cannot create 'C:\agent\_work\6\s\test\TestApp\TestApp.Client\bin\Debug\netstandard2.0\dist\_content\BlazorState.Js' because a file or directory with the same name already exists.