### PR TITLE
Fix for use clone override

### DIFF
--- a/source/BlazorState/BlazorState.csproj
+++ b/source/BlazorState/BlazorState.csproj
@@ -71,8 +71,8 @@
     </ItemGroup>
   </Target>
   <!-- End TypeScript project-->
+  
   <!--Add Version-->
-
   <Target Name="WriteVersionToFile">
     <WriteLinesToFile File="$(OutputPath)..\..\Version.txt" Lines="$(PackageVersion)" Overwrite="true" Encoding="UTF-8" />
   </Target>

--- a/source/BlazorState/Pipeline/CloneState/CloneStateBehavior.cs
+++ b/source/BlazorState/Pipeline/CloneState/CloneStateBehavior.cs
@@ -44,7 +44,7 @@
         Logger.LogDebug($"{className}: Clone State of type {responseType}");
         originalState = Store.GetState<TResponse>();
         Logger.LogDebug($"{className}: originalState.Guid:{((IState)originalState).Guid}");
-        TResponse newState = originalState.Clone();
+        TResponse newState = (originalState is ICloneable clonable) ? (TResponse)clonable.Clone() : originalState.Clone();
         Logger.LogDebug($"{className}: newState.Guid:{((IState)newState).Guid}");
         Store.SetState(newState as IState);
       }

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -18,6 +18,7 @@
     <VersionSuffix>$(PreReleaseLabel)-$(CurrentDate)</VersionSuffix>
     <PackageVersion>$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
   </PropertyGroup>
+  <!-- End Versioning properties -->
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>

--- a/test/TestApp.Client.Integration.Tests/Clone/CloneTests.cs
+++ b/test/TestApp.Client.Integration.Tests/Clone/CloneTests.cs
@@ -1,13 +1,7 @@
 ﻿namespace TestApp.Client.Integration.Tests.Clone
 {
-  using System;
-  using BlazorState;
-  using Microsoft.Extensions.DependencyInjection;
   using Shouldly;
   using TestApp.Client.Integration.Tests.Infrastructure;
-  using System.Collections.Generic;
-  using TestApp.Client.Features.WeatherForecast;
-  using TestApp.Shared.Features.WeatherForecast;
   using AnyClone;
   using System.Linq;
 
@@ -24,26 +18,7 @@
     }
     
     public IOrderedEnumerable<string> SortedFruits { get; set; }
-    //public IOrderedEnumerable<KeyValuePair<string, int>> SomeOrderedData { get; set; }
   }
-
-  //public partial class SomeState
-  //{
-  //  public class SomeHandler : RequestHandler<SomeRequest, SomeState>
-  //  {
-  //    public SomeHandler(IStore store) : base(store) { }
-
-  //    public SomeState SomeState => Store.GetState<SomeState>();
-
-  //    public override async Task<SomeState> Handle(SomeRequest req, CancellationToken token)
-  //    {
-  //      var dataSource = ...
-  //             SomeState.SomeData = from entry in dataSource orderby entry.Key select entry;
-  //      return SomeState;
-  //    }
-  //  }
-  //}
-
 
   internal class CloneTests
   {

--- a/test/TestApp.Client.Integration.Tests/Clone/CloneTests.cs
+++ b/test/TestApp.Client.Integration.Tests/Clone/CloneTests.cs
@@ -1,4 +1,4 @@
-﻿namespace TestApp.Client.Integration.Tests.Features.WeatherForecast
+﻿namespace TestApp.Client.Integration.Tests.Clone
 {
   using System;
   using BlazorState;
@@ -9,47 +9,57 @@
   using TestApp.Client.Features.WeatherForecast;
   using TestApp.Shared.Features.WeatherForecast;
   using AnyClone;
+  using System.Linq;
 
-  internal class WeatherForecastStateCloneTests
+  public class TestState
   {
-    public WeatherForecastStateCloneTests(TestFixture aTestFixture)
+    public TestState()
     {
-      IServiceProvider serviceProvider = aTestFixture.ServiceProvider;
-      IStore store = serviceProvider.GetService<IStore>();
-      WeatherForecastsState = store.GetState<WeatherForecastsState>();
+      // Create an array of strings to sort.
+      string[] fruits = { "apricot", "orange", "banana", "mango", "apple", "grape", "strawberry" };
+
+      // Sort the strings first by their length and then alphabetically
+      // by passing the identity selector function.
+      SortedFruits = fruits.OrderBy(aFruit => aFruit.Length).ThenBy(aFruit => aFruit);
     }
+    
+    public IOrderedEnumerable<string> SortedFruits { get; set; }
+    //public IOrderedEnumerable<KeyValuePair<string, int>> SomeOrderedData { get; set; }
+  }
 
-    private WeatherForecastsState WeatherForecastsState { get; set; }
+  //public partial class SomeState
+  //{
+  //  public class SomeHandler : RequestHandler<SomeRequest, SomeState>
+  //  {
+  //    public SomeHandler(IStore store) : base(store) { }
 
-    public void ShouldClone()
+  //    public SomeState SomeState => Store.GetState<SomeState>();
+
+  //    public override async Task<SomeState> Handle(SomeRequest req, CancellationToken token)
+  //    {
+  //      var dataSource = ...
+  //             SomeState.SomeData = from entry in dataSource orderby entry.Key select entry;
+  //      return SomeState;
+  //    }
+  //  }
+  //}
+
+
+  internal class CloneTests
+  {
+    public CloneTests(TestFixture aTestFixture)    {    }  
+
+    public void ShouldCloneTestState()
     {
-      //Arrange
-      var weatherForecasts = new List<WeatherForecastDto> {
-        new WeatherForecastDto
-        (
-          aDate: DateTime.MinValue,
-          aSummary: "Summary 1",
-          aTemperatureC: 24
-        ),
-        new WeatherForecastDto
-        (
-          aDate: DateTime.MinValue,
-          aSummary: "Summary 1",
-          aTemperatureC: 24
-        ),
-      };
-      WeatherForecastsState.Initialize(weatherForecasts);
-      
-      //Act
-      var clone = WeatherForecastsState.Clone() as WeatherForecastsState;
 
-      //Assert
-      WeatherForecastsState.ShouldNotBeSameAs(clone);
-      WeatherForecastsState.WeatherForecasts.Count.ShouldBe(clone.WeatherForecasts.Count);
-      WeatherForecastsState.Guid.ShouldNotBe(clone.Guid);
-      WeatherForecastsState.WeatherForecasts[0].TemperatureC.ShouldBe(clone.WeatherForecasts[0].TemperatureC);
-      WeatherForecastsState.WeatherForecasts[0].ShouldNotBe(clone.WeatherForecasts[0]);
+      // Arrange
+      var testState = new TestState();
+
+      // Act
+      TestState clone = testState.Clone();
+
+      // Assert
+      clone.SortedFruits.Count().ShouldBe(7);
     }
-
   }
 }

--- a/test/TestApp.Client.Integration.Tests/Clone/CloneTests.cs
+++ b/test/TestApp.Client.Integration.Tests/Clone/CloneTests.cs
@@ -1,0 +1,55 @@
+﻿namespace TestApp.Client.Integration.Tests.Features.WeatherForecast
+{
+  using System;
+  using BlazorState;
+  using Microsoft.Extensions.DependencyInjection;
+  using Shouldly;
+  using TestApp.Client.Integration.Tests.Infrastructure;
+  using System.Collections.Generic;
+  using TestApp.Client.Features.WeatherForecast;
+  using TestApp.Shared.Features.WeatherForecast;
+  using AnyClone;
+
+  internal class WeatherForecastStateCloneTests
+  {
+    public WeatherForecastStateCloneTests(TestFixture aTestFixture)
+    {
+      IServiceProvider serviceProvider = aTestFixture.ServiceProvider;
+      IStore store = serviceProvider.GetService<IStore>();
+      WeatherForecastsState = store.GetState<WeatherForecastsState>();
+    }
+
+    private WeatherForecastsState WeatherForecastsState { get; set; }
+
+    public void ShouldClone()
+    {
+      //Arrange
+      var weatherForecasts = new List<WeatherForecastDto> {
+        new WeatherForecastDto
+        (
+          aDate: DateTime.MinValue,
+          aSummary: "Summary 1",
+          aTemperatureC: 24
+        ),
+        new WeatherForecastDto
+        (
+          aDate: DateTime.MinValue,
+          aSummary: "Summary 1",
+          aTemperatureC: 24
+        ),
+      };
+      WeatherForecastsState.Initialize(weatherForecasts);
+      
+      //Act
+      var clone = WeatherForecastsState.Clone() as WeatherForecastsState;
+
+      //Assert
+      WeatherForecastsState.ShouldNotBeSameAs(clone);
+      WeatherForecastsState.WeatherForecasts.Count.ShouldBe(clone.WeatherForecasts.Count);
+      WeatherForecastsState.Guid.ShouldNotBe(clone.Guid);
+      WeatherForecastsState.WeatherForecasts[0].TemperatureC.ShouldBe(clone.WeatherForecasts[0].TemperatureC);
+      WeatherForecastsState.WeatherForecasts[0].ShouldNotBe(clone.WeatherForecasts[0]);
+    }
+
+  }
+}

--- a/test/TestApp.Client.Integration.Tests/Infrastructure/TestFixture.cs
+++ b/test/TestApp.Client.Integration.Tests/Infrastructure/TestFixture.cs
@@ -11,6 +11,7 @@
   using TestApp.Client.Features.Counter;
   using TestApp.Client.Features.EventStream;
   using TestApp.Client.Features.WeatherForecast;
+  using TestApp.Client.Features.CloneTest;
 
   /// <summary>
   /// A known starting state(baseline) for all tests.
@@ -56,9 +57,11 @@
       );
 
       aServiceCollection.AddTransient<ApplicationState>();
+      aServiceCollection.AddTransient<CloneTestState>();
       aServiceCollection.AddTransient<CounterState>();
       aServiceCollection.AddTransient<EventStreamState>();
       aServiceCollection.AddTransient<WeatherForecastsState>();
+
 
     }
   }

--- a/test/TestApp.Client.Integration.Tests/Pipeline/CloneStateBehaviorTests.cs
+++ b/test/TestApp.Client.Integration.Tests/Pipeline/CloneStateBehaviorTests.cs
@@ -7,6 +7,7 @@
   using Microsoft.Extensions.DependencyInjection;
   using Shouldly;
   using TestApp.Client.Features.Counter;
+  using TestApp.Client.Features.CloneTest;
   using TestApp.Client.Integration.Tests.Infrastructure;
 
   internal class CloneStateBehaviorTests
@@ -20,6 +21,7 @@
     }
 
     private CounterState CounterState { get; set; }
+    private CloneTestState CloneTestState => Store.GetState<CloneTestState>();
     private IMediator Mediator { get; }
     private IServiceProvider ServiceProvider { get; }
     private IStore Store { get; }
@@ -64,5 +66,23 @@
       CounterState = Store.GetState<CounterState>();
       CounterState.Guid.Equals(preActionGuid);
     }
+
+    public async Task ShouldCloneStateUsingOverridenClone()
+    {
+      //Arrange
+      CloneTestState.Initialize(aCount: 15);
+      Guid preActionGuid = CloneTestState.Guid;
+
+      // Create request
+      var cloneTestAction = new CloneTestAction { };
+      //Act
+      // Send Request
+      _ = await Mediator.Send(cloneTestAction);
+
+      //Assert
+      CloneTestState.Guid.ShouldNotBe(preActionGuid);
+      CloneTestState.Count.ShouldBe(42);
+    }
+
   }
 }

--- a/test/TestApp/TestApp.Client/Features/CloneTest/Actions/IncrementCount/CloneTestAction.cs
+++ b/test/TestApp/TestApp.Client/Features/CloneTest/Actions/IncrementCount/CloneTestAction.cs
@@ -1,0 +1,7 @@
+﻿namespace TestApp.Client.Features.CloneTest
+{
+  using MediatR;
+  using TestApp.Shared.Features.Base;
+
+  public class CloneTestAction : BaseRequest, IRequest<CloneTestState>  {  }
+}

--- a/test/TestApp/TestApp.Client/Features/CloneTest/Actions/IncrementCount/CloneTestHandler.cs
+++ b/test/TestApp/TestApp.Client/Features/CloneTest/Actions/IncrementCount/CloneTestHandler.cs
@@ -1,0 +1,24 @@
+﻿namespace TestApp.Client.Features.CloneTest
+{
+  using System;
+  using System.Threading;
+  using System.Threading.Tasks;
+  using BlazorState;
+  using TestApp.Client.Features.Base;
+
+  internal partial class CloneTestState
+  {
+    internal class CloneTestHandler : BaseHandler<CloneTestAction, CloneTestState>
+    {
+      public CloneTestHandler(IStore aStore) : base(aStore) { }
+
+      protected CloneTestState CloneTestState => Store.GetState<CloneTestState>();
+
+      public override Task<CloneTestState> Handle
+      (
+        CloneTestAction aIncrementCounterRequest,
+        CancellationToken aCancellationToken
+      ) => Task.FromResult(CloneTestState);
+    }
+  }
+}

--- a/test/TestApp/TestApp.Client/Features/CloneTest/Actions/IncrementCount/CloneTestHandler.cs
+++ b/test/TestApp/TestApp.Client/Features/CloneTest/Actions/IncrementCount/CloneTestHandler.cs
@@ -1,6 +1,5 @@
 ﻿namespace TestApp.Client.Features.CloneTest
 {
-  using System;
   using System.Threading;
   using System.Threading.Tasks;
   using BlazorState;

--- a/test/TestApp/TestApp.Client/Features/CloneTest/CloneTestState.Debug.cs
+++ b/test/TestApp/TestApp.Client/Features/CloneTest/CloneTestState.Debug.cs
@@ -1,0 +1,32 @@
+﻿namespace TestApp.Client.Features.CloneTest
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Reflection;
+  using BlazorState;
+  using Microsoft.JSInterop;
+
+  internal partial class CloneTestState : State<CloneTestState>
+  {
+    public override CloneTestState Hydrate(IDictionary<string, object> aKeyValuePairs)
+    {
+      var counterState = new CloneTestState()
+      {
+        Count = Convert.ToInt32(aKeyValuePairs[CamelCase.MemberNameToCamelCase(nameof(Count))].ToString()),
+        Guid = new System.Guid(aKeyValuePairs[CamelCase.MemberNameToCamelCase(nameof(Guid))].ToString()),
+      };
+
+      return counterState;
+    }
+
+    /// <summary>
+    /// Use in Tests ONLY, to initialize the State
+    /// </summary>
+    /// <param name="aCount"></param>
+    public void Initialize(int aCount)
+    {
+      ThrowIfNotTestAssembly(Assembly.GetCallingAssembly());
+      Count = aCount;
+    }
+  }
+}

--- a/test/TestApp/TestApp.Client/Features/CloneTest/CloneTestState.Debug.cs
+++ b/test/TestApp/TestApp.Client/Features/CloneTest/CloneTestState.Debug.cs
@@ -10,7 +10,7 @@
   {
     public override CloneTestState Hydrate(IDictionary<string, object> aKeyValuePairs)
     {
-      var counterState = new CloneTestState()
+      var counterState = new CloneTestState
       {
         Count = Convert.ToInt32(aKeyValuePairs[CamelCase.MemberNameToCamelCase(nameof(Count))].ToString()),
         Guid = new System.Guid(aKeyValuePairs[CamelCase.MemberNameToCamelCase(nameof(Guid))].ToString()),

--- a/test/TestApp/TestApp.Client/Features/CloneTest/CloneTestState.cs
+++ b/test/TestApp/TestApp.Client/Features/CloneTest/CloneTestState.cs
@@ -1,0 +1,19 @@
+﻿namespace TestApp.Client.Features.CloneTest
+{
+  using BlazorState;
+  using System;
+
+  internal partial class CloneTestState : State<CloneTestState>, ICloneable
+  {
+
+    public int Count { get; private set; }
+
+    public CloneTestState() { }
+
+    /// <summary>
+    /// Set the Initial State
+    /// </summary>
+    protected override void Initialize() => Count = 3;
+    public object Clone() => new CloneTestState() { Count = 42 };
+  }
+}

--- a/test/TestApp/TestApp.Client/Features/CloneTest/CloneTestState.cs
+++ b/test/TestApp/TestApp.Client/Features/CloneTest/CloneTestState.cs
@@ -14,6 +14,6 @@
     /// Set the Initial State
     /// </summary>
     protected override void Initialize() => Count = 3;
-    public object Clone() => new CloneTestState() { Count = 42 };
+    public object Clone() => new CloneTestState { Count = 42 };
   }
 }


### PR DESCRIPTION
Fix to #148 

If you implement ICloneable in `state` it will now be used instead of AnyClone.

A test case was added to confirm.