### PR TITLE
for preview versions you have to specify the version

### DIFF
--- a/Documentation/TemplateOverview.md
+++ b/Documentation/TemplateOverview.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```console
-dotnet new --install TimeWarp.AspNetCore.Blazor.Templates
+dotnet new --install TimeWarp.AspNetCore.Blazor.Templates::1.0.0-3.0.0-preview7.19365.7-*
 ```
 
 ## Usage


### PR DESCRIPTION
dotnet new --install TimeWarp.AspNetCore.Blazor.Templates::1.0.0-3.0.0-preview7.19365.7-* the star seems to work fine here.