### PR TITLE
Change Dispose + ID to virtual so the component can be correctly inherited

### DIFF
--- a/Source/BlazorState/Components/BlazorStateComponent.cs
+++ b/Source/BlazorState/Components/BlazorStateComponent.cs
@@ -26,7 +26,7 @@
     /// <summary>
     /// A generated unique Id based on the Class name and number of times they have been created
     /// </summary>
-    public string Id { get; }
+    public virtual string Id { get; }
 
     /// <summary>
     /// Allows for the Assigning of a value one can use to select an element during automated testing.
@@ -60,6 +60,6 @@
       return Store.GetState<T>();
     }
 
-    public void Dispose() => Subscriptions.Remove(this);
+    public virtual void Dispose() => Subscriptions.Remove(this);
   }
 }


### PR DESCRIPTION
In order to create a new "base" component, these two fields may/will need to be overridden to create a custom "base" component for a project that will use states.

Pretty trivial change.