### PR TITLE
Bump version

### DIFF
--- a/Build/BlazorStateMultiStage.yml
+++ b/Build/BlazorStateMultiStage.yml
@@ -6,7 +6,7 @@ pr: none
 variables:
   Major: 3
   Minor: 2
-  Patch: 2
+  Patch: 3
   DotNetSdkVersion: 3.1.300
 
 stages:


### PR DESCRIPTION
no breaking changes.  All dependent libraries bumped had no breaking changes and Blazor-State only added a workaround for a bug in how LiveSharp works.

