### PR TITLE
Error Handling

### DIFF
--- a/Source/BlazorState/Pipeline/CloneState/ExceptionNotification.cs
+++ b/Source/BlazorState/Pipeline/CloneState/ExceptionNotification.cs
@@ -1,0 +1,12 @@
+﻿namespace BlazorState.Pipeline.State
+{
+  using MediatR;
+  using System;
+
+  public class ExceptionNotification : INotification
+  {
+    public string RequestName { get; set; }
+
+    public Exception Exception { get; set; }
+  }
+}

--- a/Tests/Client.Integration.Tests/Features/Application/ApplicationState_Clone_Tests.cs
+++ b/Tests/Client.Integration.Tests/Features/Application/ApplicationState_Clone_Tests.cs
@@ -17,7 +17,7 @@ namespace ApplicationState
     public void Clone()
     {
       //Arrange
-      ApplicationState.Initialize(aName: "TestName");
+      ApplicationState.Initialize(aName: "TestName", aExceptionMessage: "Some ExceptionMessage");
 
       //Act
       ApplicationState clone = ApplicationState.Clone();
@@ -25,6 +25,7 @@ namespace ApplicationState
       //Assert
       ApplicationState.ShouldNotBeSameAs(clone);
       ApplicationState.Name.ShouldBe(clone.Name);
+      ApplicationState.ExceptionMessage.ShouldBe(clone.ExceptionMessage);
       ApplicationState.Guid.ShouldNotBe(clone.Guid);
     }
 

--- a/Tests/TestApp/Client/Features/Application/Actions/ResetStore/ResetStoreAction.cs
+++ b/Tests/TestApp/Client/Features/Application/Actions/ResetStore/ResetStoreAction.cs
@@ -2,5 +2,8 @@ namespace TestApp.Client.Features.Application
 {
   using BlazorState;
 
-  public class ResetStoreAction : IAction { }
+  internal partial class ApplicationState
+  {
+    public class ResetStoreAction : IAction { }
+  }
 }

--- a/Tests/TestApp/Client/Features/Application/Actions/ResetStore/ResetStoreHandler.cs
+++ b/Tests/TestApp/Client/Features/Application/Actions/ResetStore/ResetStoreHandler.cs
@@ -5,6 +5,7 @@ namespace TestApp.Client.Features.Application
   using System.Threading;
   using System.Threading.Tasks;
   using static BlazorState.Features.Routing.RouteState;
+  using static TestApp.Client.Features.Application.ApplicationState;
 
   internal class ResetStoreHandler : IRequestHandler<ResetStoreAction>
   {
@@ -20,7 +21,7 @@ namespace TestApp.Client.Features.Application
     public async Task<Unit> Handle(ResetStoreAction aResetStoreAction, CancellationToken aCancellationToken)
     {
       Store.Reset();
-      _ = await Sender.Send(new ChangeRouteAction { NewRoute = "/" });
+      await Sender.Send(new ChangeRouteAction { NewRoute = "/" });
       return Unit.Value;
     }
   }

--- a/Tests/TestApp/Client/Features/Application/ApplicationState.Debug.cs
+++ b/Tests/TestApp/Client/Features/Application/ApplicationState.Debug.cs
@@ -17,10 +17,11 @@ namespace TestApp.Client.Features.Application
       };
     }
 
-    internal void Initialize(string aName)
+    internal void Initialize(string aName, string aExceptionMessage)
     {
       ThrowIfNotTestAssembly(Assembly.GetCallingAssembly());
       Name = aName;
+      ExceptionMessage = aExceptionMessage;
     }
   }
 }

--- a/Tests/TestApp/Client/Features/Application/ApplicationState.cs
+++ b/Tests/TestApp/Client/Features/Application/ApplicationState.cs
@@ -5,6 +5,7 @@ namespace TestApp.Client.Features.Application
   internal partial class ApplicationState : State<ApplicationState>
   {
     public string Name { get; private set; }
+    public string ExceptionMessage { get; private set; }
 
     public string Version => GetType().Assembly.GetName().Version.ToString();
 

--- a/Tests/TestApp/Client/Features/Application/Notification/ExceptionNotificationHandler.cs
+++ b/Tests/TestApp/Client/Features/Application/Notification/ExceptionNotificationHandler.cs
@@ -1,0 +1,41 @@
+namespace TestApp.Client.Features.Application
+{
+  using BlazorState;
+  using BlazorState.Pipeline.State;
+  using MediatR;
+  using Microsoft.Extensions.Logging;
+  using System.Threading;
+  using System.Threading.Tasks;
+
+  internal partial class ApplicationState
+  {
+    internal class ExceptionNotificationHandler
+      : INotificationHandler<ExceptionNotification>
+    {
+      private readonly ILogger Logger;
+      private readonly IStore Store;
+      private ApplicationState ApplicationState => Store.GetState<ApplicationState>();
+
+      public ExceptionNotificationHandler
+      (
+        ILogger<ExceptionNotificationHandler> aLogger,
+        IStore aStore
+      )
+      {
+        Logger = aLogger;
+        Store = aStore;
+      }
+
+      public Task Handle
+      (
+        ExceptionNotification aExceptionNotification,
+        CancellationToken aCancellationToken
+      )
+      {
+        //Logger.LogDebug(aExceptionNotification.Request.GetType().Name);
+        ApplicationState.ExceptionMessage = aExceptionNotification.Exception.Message;
+        return Unit.Task;
+      }
+    }
+  }
+}

--- a/Tests/TestApp/Client/Features/Base/Components/ResetButton.razor.cs
+++ b/Tests/TestApp/Client/Features/Base/Components/ResetButton.razor.cs
@@ -1,6 +1,6 @@
 namespace TestApp.Client.Features.Base.Components
 {
-  using TestApp.Client.Features.Application;
+  using static TestApp.Client.Features.Application.ApplicationState;
 
   public class ResetButtonBase : BaseComponent
   {


### PR DESCRIPTION
Inside of CloneStateBehavior if an exception occurs we:
* Restore the previous state
* Publish an ExceptionNotification

Previously we would restore the previous state and re-throw the exception.