### PR TITLE
Update Mediatr to 10.0.1 for .NET 6 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,8 +50,8 @@
     <FixieVersion>2.2.2</FixieVersion>
     <FixieConsoleVersion>2.2.1</FixieConsoleVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
-    <MediatrExtensionsMicrosoftDependencyInjectionVersion>9.0.0</MediatrExtensionsMicrosoftDependencyInjectionVersion>
-    <MediatrVersion>9.0.0</MediatrVersion>
+    <MediatrExtensionsMicrosoftDependencyInjectionVersion>10.0.1</MediatrExtensionsMicrosoftDependencyInjectionVersion>
+    <MediatrVersion>10.0.1</MediatrVersion>
     <ScrutorVersion>3.3.0</ScrutorVersion>
     <SeleniumSupportVersion>3.141.0</SeleniumSupportVersion>
     <SeleniumWebDriverVersion>3.141.0</SeleniumWebDriverVersion>

--- a/Source/BlazorState/Pipeline/CloneState/CloneStateBehavior.cs
+++ b/Source/BlazorState/Pipeline/CloneState/CloneStateBehavior.cs
@@ -8,7 +8,8 @@ namespace BlazorState.Pipeline.State
   using System.Threading;
   using System.Threading.Tasks;
 
-  internal class CloneStateBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+  internal class CloneStateBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> 
+    where TRequest : IRequest<TResponse>
   {
     private readonly ILogger Logger;
     private readonly IMediator Mediator;

--- a/Source/BlazorState/Pipeline/ReduxDevTools/ReduxDevToolsPostProcessor.cs
+++ b/Source/BlazorState/Pipeline/ReduxDevTools/ReduxDevToolsPostProcessor.cs
@@ -13,7 +13,8 @@ namespace BlazorState.Pipeline.ReduxDevTools
   /// </summary>
   /// <typeparam name="TRequest"></typeparam>
   /// <typeparam name="TResponse"></typeparam>
-  public class ReduxDevToolsPostProcessor<TRequest, TResponse> : IRequestPostProcessor<TRequest, TResponse>
+  public class ReduxDevToolsPostProcessor<TRequest, TResponse> : IRequestPostProcessor<TRequest, TResponse> 
+    where TRequest : IRequest<TResponse>
   {
     private readonly ILogger Logger;
 

--- a/Source/BlazorState/Pipeline/RenderSubscriptions/RenderSubscriptionsPostProcessor.cs
+++ b/Source/BlazorState/Pipeline/RenderSubscriptions/RenderSubscriptionsPostProcessor.cs
@@ -3,6 +3,7 @@
 namespace BlazorState.Pipeline.State
 {
   using BlazorState;
+  using MediatR;
   using MediatR.Pipeline;
   using Microsoft.Extensions.Logging;
   using System;
@@ -11,7 +12,7 @@ namespace BlazorState.Pipeline.State
 
   internal class RenderSubscriptionsPostProcessor<TRequest, TResponse> : IRequestPostProcessor<TRequest, TResponse>
     where
-      TRequest : notnull
+      TRequest : IRequest<TResponse>
   {
     private readonly ILogger Logger;
 


### PR DESCRIPTION
This fixes #276. Updating to .NET 6 without upgrading Mediatr ends up with: https://github.com/jbogard/MediatR/issues/674 which is fixed in Mediatr 10.0.