### PR TITLE
Add BlazorStateAnalyzer to check IAction nesting vs runtime

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Pack
         run: |
+          cd Source/BlazorStateAnalyzer/
+          dotnet clean
+          dotnet build --configuration Release
           cd Source/BlazorState/
           dotnet clean
           dotnet build --configuration Release

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Steven T. Cramer</Authors>
     <Product>Blazor State</Product>
-    <PackageVersion>8.1.1+7.0.203</PackageVersion>
+    <PackageVersion>8.2.0+7.0.203</PackageVersion>
     <PackageProjectUrl>https://timewarpengineering.github.io/blazor-state/</PackageProjectUrl>
     <PackageTags>TimeWarp-State; TimeWarpState; BlazorState; Blazor; State; Blazor-State; MediatR; Mediator; Pipeline; Redux; Flux</PackageTags>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/blazor-state.git</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Steven T. Cramer</Authors>
     <Product>Blazor State</Product>
-    <PackageVersion>8.1.0+7.0.103</PackageVersion>
+    <PackageVersion>8.1.1+7.0.203</PackageVersion>
     <PackageProjectUrl>https://timewarpengineering.github.io/blazor-state/</PackageProjectUrl>
     <PackageTags>TimeWarp-State; TimeWarpState; BlazorState; Blazor; State; Blazor-State; MediatR; Mediator; Pipeline; Redux; Flux</PackageTags>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/blazor-state.git</RepositoryUrl>

--- a/Documentation/ReleaseNotes/Release8.0.0.md
+++ b/Documentation/ReleaseNotes/Release8.0.0.md
@@ -31,3 +31,7 @@ See [Migrations](xref:BlazorState:Migration7-8.md) for instructions on how to mi
 
 * Added Go Back to Route state which allows accessing the navigation history.
 * Updated the version of the Microsoft.TypeScript.MSBuild package to 5.0.3.
+
+## Release 8.2.0
+* Included BlazorStateAnalyzer, which replaces runtime checking of IActions nesting with compile-time checking for better performance.
+* [Issue 342](https://github.com/TimeWarpEngineering/blazor-state/issues/342) Doubly nested IActions throw an error.

--- a/Source/BlazorState/BlazorState.csproj
+++ b/Source/BlazorState/BlazorState.csproj
@@ -89,7 +89,11 @@
   <ItemGroup>
     <ProjectReference Include="..\BlazorStateAnalyzer\BlazorStateAnalyzer.csproj" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <None Include="..\BlazorStateAnalyzer\bin\release\netstandard2.0\BlazorStateAnalyzer.dll" Pack="true" PackagePath="analyzers\cs" />
+  </ItemGroup>
+
   <PropertyGroup>
     <PrepareForBuildDependsOn>CompileTypeScript;GetTypeScriptOutputForPublishing;$(PrepareForBuildDependsOn)</PrepareForBuildDependsOn>
     <TypeScriptTarget>ES2022</TypeScriptTarget>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.103",
+    "version": "7.0.203",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
Fix #342 

## Release 8.2.0

* Included BlazorStateAnalyzer, which replaces runtime checking of the IActions nesting with compile-time checking for better performance.
* [Issue 342](https://github.com/TimeWarpEngineering/blazor-state/issues/342) Doubly nested IActions throw an error.