### PR TITLE
Enabling chained inherits from State<> - so users can make/use their own BaseState<>

### DIFF
--- a/Source/BlazorState/Extensions/ServiceCollectionExtensions.cs
+++ b/Source/BlazorState/Extensions/ServiceCollectionExtensions.cs
@@ -125,9 +125,21 @@ public static class ServiceCollectionExtensions
           !aType.IsAbstract &&
           !aType.IsInterface &&
           aType.BaseType != null &&
-          aType.BaseType.IsGenericType &&
-          aType.BaseType.GetGenericTypeDefinition() == typeof(State<>)
+          IsSubclassOfRawGeneric(typeof(State<>),aType)
       );
+      
+      // https://stackoverflow.com/questions/457676/check-if-a-class-is-derived-from-a-generic-class
+      // performance? startup-code less important, and also while loop breaks early.
+      static bool IsSubclassOfRawGeneric(Type generic, Type? toCheck) {
+        while (toCheck != null && toCheck != typeof(object)) {
+          Type cur = toCheck.IsGenericType ? toCheck.GetGenericTypeDefinition() : toCheck;
+          if (generic == cur) {
+            return true;
+          }
+          toCheck = toCheck.BaseType;
+        }
+        return false;
+      }
 
       foreach (Type type in types)
       {


### PR DESCRIPTION
Users may want to inherit in multiple steps from State<>. These grand-children are currently not added to DI, as their generic basetype is not State<>.

I'm a little fuzzy how you are testing/your test setup (Xunit experience here), or I would have added tests. Let me know.

