### PR TITLE
Serialization

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Steven T. Cramer</Authors>
     <Product>TimeWarp State</Product>
-    <PackageVersion>11.0.0-beta.40+8.0.300</PackageVersion>
+    <PackageVersion>11.0.0-beta.41+8.0.300</PackageVersion>
     <PackageProjectUrl>https://timewarpengineering.github.io/blazor-state/</PackageProjectUrl>
     <PackageTags>TimeWarp.State; TimeWarp-State; TimeWarpState; BlazorState; Blazor; State; Blazor-State; MediatR; Mediator; Pipeline; Redux; Flux</PackageTags>
     <PackageIcon>Logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
@@ -39,7 +39,7 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.19.1" />
     <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.44.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.4.5" />
+    <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.5.2" />
     <PackageVersion Include="NUnit" Version="4.1.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.2.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/Source/TimeWarp.State/State/State.cs
+++ b/Source/TimeWarp.State/State/State.cs
@@ -1,9 +1,13 @@
 namespace TimeWarp.State;
 
+using System.Text.Json.Serialization;
+
 public abstract class State<TState> : IState<TState>
 {
   [IgnoreDataMember]
   public Guid Guid { get; protected init; } = Guid.NewGuid();
+  
+  [JsonIgnore]
   public SemaphoreSlim Semaphore { get; }  = new(1, 1);
 
   /// <summary>

--- a/Tests/Test.App/Test.App.Client/Features/CloneTest/Pages/ClonablePage.razor
+++ b/Tests/Test.App/Test.App.Client/Features/CloneTest/Pages/ClonablePage.razor
@@ -8,7 +8,7 @@
 <!-- Arrange -->
 <!-- Test description -->
 <p>
-  The StateTransactionBehavior middleware in Blazor-State is designed to use ICloneable if it is implemented and Anyclone otherwise..<br>
+  The StateTransactionBehavior middleware in TimeWarp.State is designed to use ICloneable if it is implemented and Anyclone otherwise..<br>
   This test is to verify that the IClonable interface is working as expected.<br>
   The clone method intentionally creates a new instance where the count is always 42.<br>
   And the Increment method increments the count by 1.<br>


### PR DESCRIPTION
ReduxDevtools respects JsonIgnore.
AnyClone respects IgnoreDataMember and JsonIgnore.

We don't want Either to try to serialize a semaphore. But we want ReduxDevTools to serialize the Guid. But not AnyClone.