### PR TITLE
Skip tag validation for manual workflow dispatch

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -56,8 +56,16 @@ jobs:
           $tagName = "${{ github.event.release.tag_name }}"
           echo "Release version: $releaseVersion"
           echo "Tag name: $tagName"
-          if ($releaseVersion -ne $tagName) {
-            throw "Release version ($releaseVersion) does not match tag name ($tagName)"
+          echo "Event name: ${{ github.event_name }}"
+          
+          # Only validate tag match for actual release events, not manual dispatch
+          if ("${{ github.event_name }}" -eq "release") {
+            if ($releaseVersion -ne $tagName) {
+              throw "Release version ($releaseVersion) does not match tag name ($tagName)"
+            }
+            echo "✅ Release version matches tag name"
+          } else {
+            echo "⚠️ Manual dispatch - skipping tag validation"
           }
         shell: pwsh
 


### PR DESCRIPTION
## Summary

Fix for the release workflow when manually triggered via `workflow_dispatch`.

### Issue
When manually triggering the release workflow for testing, it fails with:
```
Release version (11.0.1) does not match tag name ()
```

### Root Cause
Manual workflow dispatch doesn't have a release event, so `github.event.release.tag_name` is empty, causing the validation to fail.

### Solution
Only validate tag matching for actual release events (`github.event_name == "release"`). For manual dispatch, skip the validation with a warning message.

This allows us to test the workflow manually while still maintaining the safety check for actual releases.

## Test plan

- [ ] Manually trigger workflow via workflow_dispatch - should skip tag validation
- [ ] Create actual release - should validate tag matches version

🤖 Generated with [Claude Code](https://claude.ai/code)